### PR TITLE
Avoid extra string allocations

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -535,7 +535,7 @@ module Searchkick
       if klass.respond_to?(:document_type)
         klass.document_type
       else
-        klass.model_name.to_s.underscore
+        klass.model_name.singular
       end
     end
 


### PR DESCRIPTION
Avoid extra string allocations on Index#document_type(record), which by default fallbacks to `model_name.to_s.underscore` which creates a new string object and call Inflector every time it used. Models already have `model_name.underscore`, which is frozen, we should you it to skip a generation of tons of strings inside a huge reindexing batch.
